### PR TITLE
Feature: PySpark Truncate External Hive Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [semantic versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `truncate_external_hive_table` to `helpers/pyspark.py`.
 
 ### Changed
 
@@ -15,6 +16,7 @@ and this project adheres to [semantic versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Temporarily pin `numpy==1.24.4` due to https://github.com/numpy/numpy/issues/267100
+
 ### Removed
 
 ## [v0.3.1] - 2024-05-24

--- a/rdsa_utils/helpers/pyspark.py
+++ b/rdsa_utils/helpers/pyspark.py
@@ -794,7 +794,7 @@ def create_spark_session(
 
 
 def truncate_external_hive_table(spark: SparkSession, table_name: str) -> None:
-    """Truncate External Hive table stored on S3 or HDFS.
+    """Truncate External Hive Table stored on S3 or HDFS.
 
     Parameters
     ----------

--- a/rdsa_utils/helpers/pyspark.py
+++ b/rdsa_utils/helpers/pyspark.py
@@ -792,6 +792,7 @@ def create_spark_session(
         logger.error(f"An error occurred while creating the Spark session: {e}")
         raise
 
+
 def truncate_external_hive_table(spark: SparkSession, table_name: str) -> None:
     """Truncate External Hive table stored on S3 or HDFS.
 
@@ -830,5 +831,7 @@ def truncate_external_hive_table(spark: SparkSession, table_name: str) -> None:
         logger.info(f"Table '{table_name}' successfully truncated.")
 
     except Exception as e:
-        logger.error(f"An error occurred while truncating the table '{table_name}': {e}")
+        logger.error(
+            f"An error occurred while truncating the table '{table_name}': {e}",
+        )
         raise

--- a/rdsa_utils/helpers/pyspark.py
+++ b/rdsa_utils/helpers/pyspark.py
@@ -791,3 +791,44 @@ def create_spark_session(
     except Exception as e:
         logger.error(f"An error occurred while creating the Spark session: {e}")
         raise
+
+def truncate_external_hive_table(spark: SparkSession, table_name: str) -> None:
+    """Truncate External Hive table stored on S3 or HDFS.
+
+    Parameters
+    ----------
+    spark
+        Active SparkSession.
+    table_name
+        The name of the external Hive table to truncate.
+
+    Returns
+    -------
+    None
+        This function does not return any value. It performs an action of
+        truncating the table.
+
+    Examples
+    --------
+    Truncate a Hive table named 'my_database.my_table':
+
+    >>> truncate_external_hive_table(spark, 'my_database.my_table')
+    """
+    try:
+        logger.info(f"Attempting to truncate the table '{table_name}'")
+
+        # Read the original table to get its schema
+        original_df = spark.table(table_name)
+        schema: T.StructType = original_df.schema
+
+        # Create an empty DataFrame with the same schema
+        empty_df = spark.createDataFrame([], schema)
+
+        # Overwrite the original table with the empty DataFrame
+        empty_df.write.mode("overwrite").insertInto(table_name)
+
+        logger.info(f"Table '{table_name}' successfully truncated.")
+
+    except Exception as e:
+        logger.error(f"An error occurred while truncating the table '{table_name}': {e}")
+        raise

--- a/tests/helpers/test_pyspark.py
+++ b/tests/helpers/test_pyspark.py
@@ -1098,14 +1098,14 @@ class TestTruncateExternalHiveTable:
         spark.sql("DROP DATABASE test_db")
         spark.stop()
 
-    def test_truncate_table(self, create_external_table) -> None:
+    def test_truncate_table(self, create_external_table):
         """Test truncating an external Hive table."""
         table_name, spark_session = create_external_table
         truncate_external_hive_table(spark_session, table_name)
         truncated_df = spark_session.table(table_name)
         assert truncated_df.count() == 0
 
-    def test_schema_preservation(self, create_external_table) -> None:
+    def test_schema_preservation(self, create_external_table):
         """Test schema preservation after truncation."""
         table_name, spark_session = create_external_table
         original_schema = spark_session.table(table_name).schema
@@ -1113,7 +1113,7 @@ class TestTruncateExternalHiveTable:
         truncated_schema = spark_session.table(table_name).schema
         assert original_schema == truncated_schema
 
-    def test_no_exceptions(self, create_external_table) -> None:
+    def test_no_exceptions(self, create_external_table):
         """Test no exceptions are raised during truncation."""
         table_name, spark_session = create_external_table
         try:

--- a/tests/helpers/test_pyspark.py
+++ b/tests/helpers/test_pyspark.py
@@ -1074,3 +1074,54 @@ class TestCreateSparkSession:
             spark.conf.get("spark.ui.enabled") == "false"
         ), "Extra configurations should be applied."
         spark.stop()
+
+
+class TestTruncateExternalHiveTable:
+    """Tests for truncate_external_hive_table function."""
+
+    @pytest.fixture()
+    def create_external_table(self, spark_session: SparkSession):
+        """Create a mock external Hive table for testing."""
+        table_name = "test_db.test_table"
+        spark_session.sql("CREATE DATABASE IF NOT EXISTS test_db")
+        schema = T.StructType([T.StructField("name", T.StringType(), True)])
+        df = spark_session.createDataFrame([("Alice",), ("Bob",)], schema)
+        df.write.mode("overwrite").saveAsTable(table_name)
+        yield table_name
+        spark_session.sql(f"DROP TABLE {table_name}")
+        spark_session.sql("DROP DATABASE test_db")
+
+    def test_truncate_table(
+        self,
+        spark_session: SparkSession,
+        create_external_table: Callable,
+    ):
+        """Test truncating an external Hive table."""
+        table_name = create_external_table
+        truncate_external_hive_table(spark_session, table_name)
+        truncated_df = spark_session.table(table_name)
+        assert truncated_df.count() == 0
+
+    def test_schema_preservation(
+        self,
+        spark_session: SparkSession,
+        create_external_table: Callable,
+    ):
+        """Test schema preservation after truncation."""
+        table_name = create_external_table
+        original_schema = spark_session.table(table_name).schema
+        truncate_external_hive_table(spark_session, table_name)
+        truncated_schema = spark_session.table(table_name).schema
+        assert original_schema == truncated_schema
+
+    def test_no_exceptions(
+        self,
+        spark_session: SparkSession,
+        create_external_table: Callable,
+    ):
+        """Test no exceptions are raised during truncation."""
+        table_name = create_external_table
+        try:
+            truncate_external_hive_table(spark_session, table_name)
+        except Exception as e:
+            pytest.fail(f"Truncation raised an exception: {e}")


### PR DESCRIPTION
## Description

Added `truncate_external_hive_table` to `helpers/pyspark.py`.

- [x] New feature - *non-breaking change*

## Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code appropriately, focusing on explaining my design decisions (explain why, not how).
- [x] I have made corresponding changes to the documentation (comments, docstring, etc.. )
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated the change log.

<br>

#  Peer review
Any new code includes all the following:

- **Documentation**: docstrings, comments have been added/ updated.
- **Style guidelines**: New code conforms to the project's contribution guidelines.
- **Functionality**: The code works as expected, handles expected edge cases and exceptions are handled appropriately.
- **Complexity**: The code is not overly complex, logic has been split into appropriately sized functions, etc..
- **Test coverage**: Unit tests cover essential functions for a reasonable range of inputs and conditions. Added and existing tests pass on my machine.

### Review comments
Suggestions should be tailored to the code that you are reviewing. Provide context.
Be critical and clear, but not mean. Ask questions and set actions.
<details><summary>These might include:</summary>

- bugs that need fixing (does it work as expected? and does it work with other code
  that it is likely to interact with?)
- alternative methods (could it be written more efficiently or with more clarity?)
- documentation improvements (does the documentation reflect how the code actually works?)
- additional tests that should be implemented
  - Do the tests effectively assure that it
  works correctly? Are there additional edge cases/ negative tests to be considered?
- code style improvements (could the code be written more clearly?)
</details>
<br>

*Further reading: [code review best practices](https://best-practice-and-impact.github.io/qa-of-code-guidance/peer_review.html)*