### PR TITLE
Fix load_csv docstring in helpers/pyspark.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [semantic versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Fixed docstring for `load_csv` in `helpers/pyspark.py`.
 
 ### Deprecated
 

--- a/rdsa_utils/helpers/pyspark.py
+++ b/rdsa_utils/helpers/pyspark.py
@@ -844,13 +844,6 @@ def load_csv(
         If a column specified in rename_columns, drop_columns, or
         keep_columns is not found in the DataFrame.
 
-    Notes
-    -----
-    Transformation order:
-    1. Columns are kept according to `keep_columns`.
-    2. Columns are dropped according to `drop_columns`.
-    3. Columns are renamed according to `rename_columns`.
-
     Examples
     --------
     Load a CSV file with multiline and rename columns:
@@ -877,7 +870,6 @@ def load_csv(
     Load a CSV file with custom delimiter and multiline:
 
     >>> df = load_csv(spark, "/path/to/file.csv", sep=";", multiLine=True)
-
     """
     try:
         df = spark.read.csv(filepath, header=True, **kwargs)


### PR DESCRIPTION
## Description

Fixed docstring for `load_csv` in `helpers/pyspark.py`.

- [x] Non-user facing change, structural change, dev functionality, docs ...

## Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code appropriately, focusing on explaining my design decisions (explain why, not how).
- [x] I have made corresponding changes to the documentation (comments, docstring, etc.. )
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated the change log.

<br>

#  Peer review
Any new code includes all the following:

- **Documentation**: docstrings, comments have been added/ updated.
- **Style guidelines**: New code conforms to the project's contribution guidelines.
- **Functionality**: The code works as expected, handles expected edge cases and exceptions are handled appropriately.
- **Complexity**: The code is not overly complex, logic has been split into appropriately sized functions, etc..
- **Test coverage**: Unit tests cover essential functions for a reasonable range of inputs and conditions. Added and existing tests pass on my machine.

### Review comments
Suggestions should be tailored to the code that you are reviewing. Provide context.
Be critical and clear, but not mean. Ask questions and set actions.
<details><summary>These might include:</summary>

- bugs that need fixing (does it work as expected? and does it work with other code
  that it is likely to interact with?)
- alternative methods (could it be written more efficiently or with more clarity?)
- documentation improvements (does the documentation reflect how the code actually works?)
- additional tests that should be implemented
  - Do the tests effectively assure that it
  works correctly? Are there additional edge cases/ negative tests to be considered?
- code style improvements (could the code be written more clearly?)
</details>
<br>

*Further reading: [code review best practices](https://best-practice-and-impact.github.io/qa-of-code-guidance/peer_review.html)*