### PR TITLE
Data File Fix PySpark Log Parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [semantic versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `include_package_data = True` and
+  `rdsa_utils.helpers.pyspark_log_parser = *.db, *.ipynb`
+  to `setup.cfg` to include `.db` and `.ipynb` files
+  in the `pyspark_log_parser` module.
 
 ### Changed
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ where = .
 include = rdsa_utils*
 
 [options.package_data]
-* = *.db
+rdsa_utils.helpers.pyspark_log_parser = *.db, *.ipynb
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
Added `include_package_data = True` and `rdsa_utils.helpers.pyspark_log_parser = *.db, *.ipynb` to `setup.cfg` to include `.db` and `.ipynb` files in the `pyspark_log_parser` module.
