### PR TITLE
DB Data File Fix in setup.cfg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [semantic versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 ### Fixed
+- Fixed `setup.cfg` to include `data/*.db` files in the `pyspark_log_parser` module.
 
 ### Removed
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ where = .
 include = rdsa_utils*
 
 [options.package_data]
-rdsa_utils.helpers.pyspark_log_parser = *.db, *.ipynb
+rdsa_utils.helpers.pyspark_log_parser = data/*.db, *.ipynb
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
Fixed `setup.cfg` to include `data/*.db` files in the `pyspark_log_parser` module.