### PR TITLE
Fix: Pin mkdocs Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [semantic versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Pinned `mkdocs` to `1.6.0` in `doc` extra to resolve dependency
+  conflict with `ons-mkdocs-theme`.
 
 ### Deprecated
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ dev =
     isort>=5.13.2
     freezegun
 doc =
-    mkdocs>=1.4.2
+    mkdocs==1.6.0  # Pinning to resolve conflict with ons-mkdocs-theme
     ons-mkdocs-theme>=1.1.3
     mkdocstrings[python]>=0.22.0
     mkdocs-git-revision-date-localized-plugin>=1.2.1


### PR DESCRIPTION
Pinned `mkdocs` to `1.6.0` in `doc` extra to resolve dependency conflict with `ons-mkdocs-theme`.