### PR TITLE
Fix: cut_lineage PySpark Fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [semantic versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Updated `cut_lineage` function in `helpers/pyspark.py` to include a fallback for
+  PySpark 3.2.3 when accessing the `sparkSession` attribute.
 
 ### Deprecated
 

--- a/rdsa_utils/helpers/pyspark.py
+++ b/rdsa_utils/helpers/pyspark.py
@@ -581,7 +581,14 @@ def cut_lineage(df: SparkDF) -> SparkDF:
         jrdd = df._jdf.toJavaRDD()
         jschema = df._jdf.schema()
         jrdd.cache()
-        spark = df.sparkSession
+
+        # Check for sparkSession attribute (introduced in Spark 3.3.0)
+        if hasattr(df, "sparkSession"):
+            spark = df.sparkSession
+        else:
+            # Fallback for Spark 3.2.3
+            spark = df.sql_ctx.sparkSession
+
         new_java_df = spark._jsparkSession.createDataFrame(jrdd, jschema)
         new_df = SparkDF(new_java_df, spark)
         return new_df


### PR DESCRIPTION
## Description

Updated `cut_lineage` function in `helpers/pyspark.py` to include a fallback for PySpark 3.2.3 when accessing the `sparkSession` attribute.

- [x] New feature - *non-breaking change*

## Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code appropriately, focusing on explaining my design decisions (explain why, not how).
- [x] I have made corresponding changes to the documentation (comments, docstring, etc.. )
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated the change log.

<br>

#  Peer review
Any new code includes all the following:

- **Documentation**: docstrings, comments have been added/ updated.
- **Style guidelines**: New code conforms to the project's contribution guidelines.
- **Functionality**: The code works as expected, handles expected edge cases and exceptions are handled appropriately.
- **Complexity**: The code is not overly complex, logic has been split into appropriately sized functions, etc..
- **Test coverage**: Unit tests cover essential functions for a reasonable range of inputs and conditions. Added and existing tests pass on my machine.

### Review comments
Suggestions should be tailored to the code that you are reviewing. Provide context.
Be critical and clear, but not mean. Ask questions and set actions.
<details><summary>These might include:</summary>

- bugs that need fixing (does it work as expected? and does it work with other code
  that it is likely to interact with?)
- alternative methods (could it be written more efficiently or with more clarity?)
- documentation improvements (does the documentation reflect how the code actually works?)
- additional tests that should be implemented
  - Do the tests effectively assure that it
  works correctly? Are there additional edge cases/ negative tests to be considered?
- code style improvements (could the code be written more clearly?)
</details>
<br>

*Further reading: [code review best practices](https://best-practice-and-impact.github.io/qa-of-code-guidance/peer_review.html)*