### PR TITLE
Add function: has_no_nulls()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [semantic versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added function `has_no_nulls` to `helpers/pyspark.py`.
 
 ### Changed
 

--- a/rdsa_utils/helpers/pyspark.py
+++ b/rdsa_utils/helpers/pyspark.py
@@ -1794,3 +1794,28 @@ def filter_out_values(
         condition = base_condition
 
     return df.filter(condition)
+
+
+def has_no_nulls(df: SparkDF, column_name: str) -> bool:
+    """Check whether a specified column in a SparkDF contains no null values.
+
+    Parameters
+    ----------
+    df
+        SparkDF to check.
+    column_name
+        Name of the column to inspect for null values.
+
+    Returns
+    -------
+    bool
+        True if the column contains no nulls, False otherwise.
+    """
+    has_null = df.filter(F.col(column_name).isNull()).limit(1).count() > 0
+    if has_null:
+        error_msg = f"Column '{column_name}' contains null values."
+        logger.error(error_msg)
+        return False
+    else:
+        logger.info(f"Column '{column_name}' contains no null values.")
+        return True

--- a/rdsa_utils/helpers/pyspark.py
+++ b/rdsa_utils/helpers/pyspark.py
@@ -1811,8 +1811,8 @@ def has_no_nulls(df: SparkDF, column_name: str) -> bool:
     bool
         True if the column contains no nulls, False otherwise.
     """
-    has_null = df.filter(F.col(column_name).isNull()).limit(1).count() > 0
-    if has_null:
+    found_null = df.filter(F.col(column_name).isNull()).first()
+    if found_null:
         error_msg = f"Column '{column_name}' contains null values."
         logger.error(error_msg)
         return False

--- a/tests/helpers/test_pyspark.py
+++ b/tests/helpers/test_pyspark.py
@@ -1852,3 +1852,40 @@ class TestFilterOutValues:
         expected = create_spark_df([schema, (1.1,), (3.3,), (None,)])
         result = filter_out_values(df, "val", [2.2, 4.4])
         assert_df_equality(result, expected, ignore_row_order=True)
+
+
+class TestHasNoNullsWithValidData:
+    """Tests for has_no_nulls function."""
+
+    def test_no_nulls_in_column(self, create_spark_df: Callable) -> None:
+        """Test column with no nulls returns True."""
+        schema = T.StructType([T.StructField("id", T.IntegerType(), True)])
+        df = create_spark_df([schema, (1,), (2,), (3,)])
+        assert has_no_nulls(df, "id") is True
+
+
+class TestHasNoNulls:
+    """Tests has_no_nulls with a column that contains nulls."""
+
+    def test_column_with_some_nulls(self, create_spark_df: Callable) -> None:
+        """Test column with some nulls returns False."""
+        schema = T.StructType([T.StructField("id", T.IntegerType(), True)])
+        df = create_spark_df([schema, (1,), (None,), (3,)])
+        assert has_no_nulls(df, "id") is False
+
+    def test_all_nulls_column(self, create_spark_df: Callable) -> None:
+        """Test column with all nulls returns False."""
+        schema = T.StructType([T.StructField("id", T.IntegerType(), True)])
+        df = create_spark_df([schema, (None,), (None,)])
+        assert has_no_nulls(df, "id") is False
+
+    def test_empty_dataframe(self, create_spark_df: Callable) -> None:
+        """Test empty DataFrame returns True."""
+        schema = T.StructType([T.StructField("id", T.IntegerType(), True)])
+        df = create_spark_df(
+            [
+                schema,
+                # No rows
+            ],
+        )
+        assert has_no_nulls(df, "id") is True


### PR DESCRIPTION
## Description

Added function `has_no_nulls` to `helpers/pyspark.py`.

- [x] New feature - *non-breaking change*

## Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code appropriately, focusing on explaining my design decisions (explain why, not how).
- [x] I have made corresponding changes to the documentation (comments, docstring, etc.. )
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated the change log.

<br>

#  Peer review
Any new code includes all the following:

- **Documentation**: docstrings, comments have been added/ updated.
- **Style guidelines**: New code conforms to the project's contribution guidelines.
- **Functionality**: The code works as expected, handles expected edge cases and exceptions are handled appropriately.
- **Complexity**: The code is not overly complex, logic has been split into appropriately sized functions, etc..
- **Test coverage**: Unit tests cover essential functions for a reasonable range of inputs and conditions. Added and existing tests pass on my machine.

### Review comments
Suggestions should be tailored to the code that you are reviewing. Provide context.
Be critical and clear, but not mean. Ask questions and set actions.
<details><summary>These might include:</summary>

- bugs that need fixing (does it work as expected? and does it work with other code
  that it is likely to interact with?)
- alternative methods (could it be written more efficiently or with more clarity?)
- documentation improvements (does the documentation reflect how the code actually works?)
- additional tests that should be implemented
  - Do the tests effectively assure that it
  works correctly? Are there additional edge cases/ negative tests to be considered?
- code style improvements (could the code be written more clearly?)
</details>
<br>

*Further reading: [code review best practices](https://best-practice-and-impact.github.io/qa-of-code-guidance/peer_review.html)*